### PR TITLE
Fix crash when user taps on visualizer

### DIFF
--- a/Classes/UI/Reusable/VisualizerView.swift
+++ b/Classes/UI/Reusable/VisualizerView.swift
@@ -228,23 +228,16 @@ class VisualizerView: UIView {
             for x in 0 ..< specWidth / 2 {
                 var fftData = GaplessPlayer.si.visualizer.fftData(index: x + 1)
                 fftValues[fftValuesIndex] = fftData
-                fftValuesIndex += 1
-                if fftValuesIndex > fftValues.count - 1 {
-                    fftValuesIndex = 0
-                }
+                fftValuesIndex = fftValuesIndex + 1 > fftValues.count - 1 ? 0 : fftValuesIndex + 1
+
                 fftData = Float(fftValues.reduce(0, +)) / Float(fftValues.count)
                 
                 // Scale it (sqrt to make low values more visible)
                 let fftSqrt = sqrt(fftData)
                 y = Int(fftSqrt * 3 * Float(specHeight) - 4)
-                
-                // Linear
-                //y = fftData * 10 * specHeight
-                
+            
                 // Cap it
-                if y > specHeight {
-                    y = specHeight - 1
-                }
+                y = min(specHeight - 1, y)
                 
                 // Interpolate from previous to make the display smoother
                 y1 = (y + y1) / 2 - 1

--- a/Images/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Images/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -88,6 +88,11 @@
       "idiom" : "ipad",
       "filename" : "Icon-83.5@2x.png",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {


### PR DESCRIPTION
When the user taps on the visualizer, and this one swipe to skinnyBar type, then got a crash, this was because sometimes the value of Y was hight than specHeight and when bufferIndex is calculated then got an negative index from `(specHeight - 1 - y )` operation.

To fix this crash, I added an min() function that check whether specHeight or Y is minor value and set it to Y variable.